### PR TITLE
fix type error in js documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ MapLoader
 const MapLoader = new GoogleMap();
 
 // Load the map
-const await google_map = MapLoader.initMap(map_loader_options);
+const google_map = await MapLoader.initMap(map_loader_options);
 ```
 
 ## Documentation


### PR DESCRIPTION
# Fix type error in the code in JS README

## Description
Updated line to load google maps using await in README